### PR TITLE
Disable KDE auto-lock for gazebo user and document auto-login

### DIFF
--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -85,6 +85,7 @@ RUN useradd -m -s /bin/bash gazebo \
 # - Create VNC directory and password file for gazebo user
 # - Set up desktop directory with Gazebo shortcut
 # - Copy configuration files to gazebo user's home
+# - Disable KDE screen auto-lock to keep sessions active
 # - Set proper ownership and permissions for all gazebo user files
 RUN mkdir -p /home/gazebo/.vnc \
     && printf "1234\n1234\n\n" | vncpasswd -f > /home/gazebo/.vnc/passwd \
@@ -94,6 +95,8 @@ RUN mkdir -p /home/gazebo/.vnc \
     && cp /root/.gtkrc-2.0 /home/gazebo/ \
     && mkdir -p /home/gazebo/.config/fontconfig \
     && cp /root/.config/fontconfig/fonts.conf /home/gazebo/.config/fontconfig/ \
+    && mkdir -p /home/gazebo/.config \
+    && printf "[Daemon]\nAutolock=false\nLockOnSuspend=false\n" > /home/gazebo/.config/kscreenlockerrc \
     && chown -R gazebo:gazebo /home/gazebo
 
 # Configure automatic KDE login

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ docker compose up -d
 - **Desktop**: Click the Gazebo icon on the desktop to launch the simulator
 
 ### 4. Login Credentials (if needed)
+- The container automatically logs into the `gazebo` user, and the KDE screen locker is disabled to keep sessions active.
 - **Username**: `gazebo`
 - **Password**: `password12345!`
 


### PR DESCRIPTION
## Summary
- disable KDE screen auto-lock by writing a `kscreenlockerrc` to the gazebo user’s config
- document that the container auto-logs into the gazebo account and keeps sessions unlocked

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build --build-arg BASE_IMAGE=ghcr.io/wkronmiller/docker-ros-gazebo:latest -f Dockerfile.gui .` *(fails: Cannot connect to the Docker daemon)*
- `dockerd` *(fails: iptables permission denied when initializing network controller)*

------
https://chatgpt.com/codex/tasks/task_e_688b5cf10160832da11e0f75996fdf04