### PR TITLE
Add MAVROS packages to base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -53,11 +53,13 @@ RUN apt-get update && \
 
 # Install ROS2 desktop meta-package and build tools
 # - ros-humble-desktop: Complete ROS2 installation with GUI tools (RViz, rqt, etc.)
+# - ros-humble-mavros, ros-humble-mavros-msgs: MAVLink integration packages for autopilot communication
 # - python3-rosdep2: Dependency management tool for ROS packages
 # - python3-colcon-common-extensions: Build system for ROS2 workspaces
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       ros-${ROS_DISTRO}-desktop \
+      ros-${ROS_DISTRO}-mavros ros-${ROS_DISTRO}-mavros-msgs \
       python3-rosdep2 python3-colcon-common-extensions \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ FROM base AS ros
 - ROS2 Humble desktop meta-package (includes RViz, rqt tools)
 - Gazebo Classic robot simulator
 - ROS2-Gazebo bridge packages (`gazebo-ros`, `gazebo-ros-pkgs`)
+- MAVROS packages (`ros-humble-mavros`, `ros-humble-mavros-msgs`) for MAVLink autopilot communication
 - Python development tools (`rosdep2`, `colcon`)
 - Comprehensive theming packages for professional GUI
 - Font packages for text rendering


### PR DESCRIPTION
## Summary
- install ros-humble-mavros and ros-humble-mavros-msgs in base image
- document included MAVROS support in README

## Testing
- `make print-tag`


------
https://chatgpt.com/codex/tasks/task_e_688b642d1540832dae38e3a219935424