### PR TITLE
Layer Dockerfiles for ROS, Gazebo, and GUI

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,40 +1,14 @@
 # =============================================================================
-# Multi-stage Dockerfile for ROS2 Humble + Gazebo Classic with VNC GUI access
+# Base Dockerfile for ROS2 Humble
 # =============================================================================
-# This Dockerfile creates a containerized environment for robotics development
-# with ROS2, Gazebo simulation, and remote GUI access via VNC.
-#
-# Architecture:
-# - Stage 0 (base): CUDA-enabled Ubuntu with KDE Plasma desktop and VNC server
-# - Stage 1 (ros): ROS2 Humble installation with Gazebo Classic integration  
-# - Stage 2 (final): User setup, configuration files, and VNC customization
+# Provides a minimal ROS2 environment built on top of CUDA-enabled Ubuntu.
+# Additional Dockerfiles layer on Gazebo and GUI support.
 # =============================================================================
 
-# -----------------------------------------------------------------------------
-# Stage 0: Base system with CUDA support and desktop environment
-# -----------------------------------------------------------------------------
 FROM nvidia/cuda:12.3.2-base-ubuntu22.04
 
 # Prevent interactive prompts during package installation
-# Essential for automated Docker builds
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Install complete desktop environment and VNC server components
-# - kde-plasma-desktop: Full KDE Plasma desktop environment for GUI applications
-# - konsole: Terminal emulator integrated with KDE
-# - plasma-workspace: Core Plasma shell and workspace components
-# - kwin-x11: KDE window manager for X11 (essential for window management)
-# - xvfb: Virtual framebuffer X server for headless operation
-# - tigervnc-*: VNC server implementation for remote desktop access
-# - tightvncserver: Additional VNC tools (provides vncpasswd utility)
-# - dbus-x11: D-Bus session bus for desktop application communication
-# - sudo: Allow non-root users to execute privileged commands
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      kde-plasma-desktop konsole plasma-workspace kwin-x11 \
-      xvfb \
-      tigervnc-standalone-server tigervnc-common tightvncserver \
-      dbus-x11 sudo \
-    && rm -rf /var/lib/apt/lists/*
 
 # Set ROS2 distribution version as environment variable for consistency
 ENV ROS_DISTRO=humble
@@ -49,7 +23,8 @@ RUN apt-get update && \
     && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
          | apt-key add - \
     && echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
-         > /etc/apt/sources.list.d/ros2.list
+         > /etc/apt/sources.list.d/ros2.list \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install ROS2 desktop meta-package and build tools
 # - ros-humble-desktop: Complete ROS2 installation with GUI tools (RViz, rqt, etc.)

--- a/Dockerfile.gazebo
+++ b/Dockerfile.gazebo
@@ -17,7 +17,6 @@ RUN apt-get update && \
       ros-${ROS_DISTRO}-gazebo-ros-pkgs \
       ros-${ROS_DISTRO}-gazebo-plugins \
       ros-${ROS_DISTRO}-xacro \
-      ros-${ROS_DISTRO}-gazebo-ros-pkgs \
       ros-${ROS_DISTRO}-robot-state-publisher \
       ros-${ROS_DISTRO}-controller-manager \
       ros-${ROS_DISTRO}-ros2-controllers \

--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -4,17 +4,23 @@ ARG BASE_IMAGE
 # -----------------------------------------------------------------------------
 FROM ${BASE_IMAGE} AS final
 
-# Install comprehensive theming and font packages for professional GUI appearance
-# Font packages:
-# - fontconfig: Font configuration and management system
-# - fonts-dejavu, fonts-liberation: High-quality open source fonts
-# GTK/Qt theming packages:
-# - gtk2-engines-*: GTK2 theme engines for consistent widget appearance
-# - gnome-themes-extra, adwaita-icon-theme: Modern theme components
-# - ubuntu-mono, yaru-theme-*: Ubuntu's default theme and icon set
-# - qt5-style-*: Qt5 style plugins for theme consistency across toolkits
-# - gsettings-desktop-schemas: Configuration schemas for desktop settings
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install desktop environment, VNC server, and theming packages
+# Desktop components:
+# - kde-plasma-desktop, konsole, plasma-workspace, kwin-x11
+# - xvfb, tigervnc-standalone-server, tigervnc-common, tightvncserver
+# - dbus-x11, sudo
+# Theming and fonts:
+# - fontconfig, fonts-dejavu, fonts-liberation
+# - gtk2-engines-*, gnome-themes-extra, adwaita-icon-theme
+# - ubuntu-mono, yaru-theme-*, qt5-style-*, gsettings-desktop-schemas
 RUN apt-get update && apt-get install -y --no-install-recommends \
+      kde-plasma-desktop konsole plasma-workspace kwin-x11 \
+      xvfb \
+      tigervnc-standalone-server tigervnc-common tightvncserver \
+      dbus-x11 sudo \
       fontconfig fonts-dejavu fonts-liberation \
       gtk2-engines-murrine gtk2-engines-pixbuf \
       gnome-themes-extra adwaita-icon-theme \


### PR DESCRIPTION
## Summary
- Strip GUI components from the base image to provide a minimal CUDA-enabled ROS 2 environment.
- Add a Gazebo layer that installs simulation and ROS integration packages on top of the base.
- Move desktop environment, VNC server, and theming configuration into the GUI layer with user setup.

## Testing
- `docker build -f Dockerfile.base .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_e_688ca466a6f0832d99122210c94d08b5